### PR TITLE
change global listener to component level listener

### DIFF
--- a/src/app/modules/range-slider/range-slider.component.ts
+++ b/src/app/modules/range-slider/range-slider.component.ts
@@ -308,7 +308,7 @@ getlength(num) {
     let pixel = this.valToPixelFactor * (value - this.min);
     return pixel;
   }
-  @HostListener('window:mousemove', ['$event'])
+  @HostListener('mousemove', ['$event'])
   mouseMove(event: any) {
     if(this.minSelected || this.maxSelected){
     if (this.minSelected) {


### PR DESCRIPTION
The global listener for mouse move is preventing text selection anywhere on the screen